### PR TITLE
Fix missing header

### DIFF
--- a/src/Path.h
+++ b/src/Path.h
@@ -82,6 +82,7 @@
 #include <cxxabi.h>             // name-demangling
 // #include <typeinfo>             // typeid()
 
+#include <iostream>
 #include <string>
 #include <queue>
 #include <vector>


### PR DESCRIPTION
Compile failed due to missing <iostream>