### PR TITLE
Add darshan support as LD_PRELOAD in pfcp, pfls, pfcm

### DIFF
--- a/etc/pftool.mpi.cfg
+++ b/etc/pftool.mpi.cfg
@@ -23,7 +23,8 @@ logging: False
 #Enables n-to-1 writing
 parallel_dest: True
 
-
+#Enable a darshan logging tool
+#darshanlib: /usr/projects/darshan/sw/toss-x86_64/lib/libdarshan.so
 
 
 [options]

--- a/scripts/pfcm
+++ b/scripts/pfcm
@@ -117,6 +117,9 @@ def main():
     mpiroot= os.path.dirname(os.path.dirname(findexec(mpigo)))		# should return the MPI installation root
     pfcmd.add("-prefix", mpiroot)					# this is a fix for "orted: command not found" issue
 
+    # Add darshan logging support if its available (this must be called after adding mpigo)
+    add_darshan(config, pfcmd)
+
     if "all" not in host_list:
         pfcmd.add("-host", ",".join(host_list))
     pfcmd.add("-n", num_procs)

--- a/scripts/pfcp
+++ b/scripts/pfcp
@@ -165,6 +165,9 @@ def main():
     mpiroot= os.path.dirname(os.path.dirname(findexec(mpigo)))		# should return the MPI installation root
     pfcmd.add("-prefix", mpiroot)					# this is a fix for "orted: command not found" issue
 
+    # Add darshan logging support if its available (this must be called after adding mpigo)
+    add_darshan(config, pfcmd)
+
     if "all" not in host_list:
         pfcmd.add("-host", ",".join(host_list))
     pfcmd.add("-n", num_procs)

--- a/scripts/pfls
+++ b/scripts/pfls
@@ -76,6 +76,9 @@ def main():
     mpiroot= os.path.dirname(os.path.dirname(findexec(mpigo)))		# should return the MPI installation root
     pfcmd.add("-prefix", mpiroot)					# this is a fix for "orted: command not found" issue
 
+    # Add darshan logging support if its available (this must be called after adding mpigo)
+    add_darshan(config, pfcmd)
+
     if "all" not in host_list:
         pfcmd.add("-host", ",".join(host_list))
     pfcmd.add("-n", num_procs)

--- a/scripts/pfscripts.py
+++ b/scripts/pfscripts.py
@@ -156,6 +156,21 @@ def get_nodeallocation():
 
   return(nodelist,numprocs)
 
+def add_darshan(pfconfig, mpicmd):
+    # If darshan is specified in the environment and valid, add it to the mpi command line
+    try:
+      darshanlib = pfconfig.get("environment", "darshanlib");
+      if os.access(darshanlib, os.R_OK):
+        new_preload = darshanlib
+        orig_preload = os.environ.get("LD_PRELOAD")
+        if orig_preload:
+           new_preload +=  ":" + orig_preload
+        darshan_preload = "LD_PRELOAD=" + new_preload
+        mpicmd.add("-x", darshan_preload)
+    except:
+      pass
+
+
 def busy(): 
     print"""
 *******************************************************************


### PR DESCRIPTION
This commit adds the ability to specify darshanlib in the config
file and link in darshan at runtime.  If the darshanlib variable
points at something invalid, then nothing happens.  If
darshanlib points at a valid libdarshan.so (or any other valid
*.so), that file will be linked in via LD_PRELOAD.  This isn't
generally unsafe (the user can use LD_PRELOAD as well), but it
could lead to weird behavior if someone changes the darshanlib
variable point at something ridiculous.

By default, we disable this in the config file, but darshan support
is pretty inocuous, and I expect it is useful in production.