### PR TITLE
Closes Issue 44

### DIFF
--- a/scripts/pfscripts.py
+++ b/scripts/pfscripts.py
@@ -8,7 +8,6 @@ import ConfigParser
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 ROOT_PATH = lambda *args: os.path.join(ROOT, *args)
-pftool = ROOT_PATH("..", "bin", "pftool")
 
 class Work:
   COPY = 0
@@ -43,7 +42,7 @@ def get_jid():
   jid = user+time_id+hostname
   return jid
 
-def parse_config(options_path=ROOT_PATH("..", "etc", "pftool.cfg")):
+def parse_config(options_path=os.getenv('PFTOOL_CONFIG', ROOT_PATH("..", "etc", "pftool.cfg"))):
   config = ConfigParser.ConfigParser()
   config.read(options_path)
   return config
@@ -181,3 +180,13 @@ def busy():
 * Contact:  ICN Consulting Office (5-4444 option 3)               *
 *******************************************************************
 """
+
+"""
+Checks if pftool is in the path with fidexec, which returns None if not found
+If it is not in the path, use the old default behaviour.
+Then check if it is in the environment and possibly use that.
+"""
+pftool_temp=findexec('pftool')
+if pftool_temp is None:
+  pftool_temp=ROOT_PATH("..","bin","pftool")
+pftool=os.getenv('PFTOOL', pftool_temp)


### PR DESCRIPTION
The default behaviour was to use ../bin/pftool as the location for pftool. Now it uses an environment variable (PFTOOL) as the location, and failing that, uses the location in the PATH variable, and failing that goes back to the default behaviour. It also lookis for PFTOOL_CONFIG in the environment variables, but falls back to its old default behaviour of ../etc/pftool.cfg