### PR TITLE
New marfs build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,17 @@ AS_IF([test x$enable_s3 == xyes],
 AS_IF([test x$enable_marfs == xyes],
   [AC_CHECK_HEADERS([common.h marfs_ops.h aws4c.h aws4c_extra.h])]
 )
+AS_IF([test x"$enable_marfs" == xyes],
+  [AC_CHECK_LIB([xml2], [xmlSAX2GetEntity])
+   AC_CHECK_LIB([curl], [curl_easy_cleanup])
+   AC_CHECK_LIB([aws4c_extra], [s3_create_bucket], [], [], [-laws4c])
+   AC_CHECK_LIB([aws4c], [s3_enable_Scality_extensions])
+   AC_CHECK_LIB([marfs], [mc_put],
+                [LIBS = -lmarfs $LIBS -lisal -lne
+                 AC_DEFINE(HAVE_LIBMARFS)],
+                [AC_CHECK_LIB([marfs], [marfs_open], [],
+                              [AC_ERROR([could not find libmarfs])])],
+                [-lisal -lne])])
 
 # checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_PID_T

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,8 +51,7 @@ s3_ldflags=$(_s3_ldflags) -laws4c -laws4c_extra -lcurl -lxml2
 endif
 
 if MARFS
-marfs_cflags=$(_marfs_cflags) -DMARFS
-marfs_ldflags=$(_marfs_ldflags) -laws4c -laws4c_extra -lcurl -lxml2 -lmarfs
+marfs_cflags=-DMARFS
 install-exec-local:
 	chmod u+s $(bindir)/pftool
 	chmod g-s $(bindir)/pftool

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,7 @@ endif
 
 if MARFS
 marfs_cflags=$(_marfs_cflags) -DMARFS
-marfs_ldflags=$(_marfs_ldflags) -laws4c -laws4c_extra -lcurl -lxml2 -lmarfs -lconfig
+marfs_ldflags=$(_marfs_ldflags) -laws4c -laws4c_extra -lcurl -lxml2 -lmarfs
 install-exec-local:
 	chmod u+s $(bindir)/pftool
 	chmod g-s $(bindir)/pftool


### PR DESCRIPTION
These are changes that will support the new MarFS build process once it is merged. Some things have been moved and no longer need to be linked by pftool (like libconfig).

I have also added support for linking libne and libisal if marfs was built with Multi-Component storage enabled.

To use the new updated build you will no longer need to have `MARFS_LDFLAGS` or `MARFS_CFLAGS` in your environment. Instead you can tell configure where to look using the `LDFLAGS` and `CPPFLAGS` variables on the command line or in your environment. For example

```
$ ./configure --enable-marfs LDFLAGS="-L/path/to/marfs -L/path/to/aws4c" CPPFLAGS="-I/path/to/marfs/fuse/src -I/path/to/marfs/common/log/src -I/path/to/aws4c"
```

The output of the configure script will indicate whether it thinks marfs has MC enabled. If it can't detect multi-component it will look for marfs without multicomponent and will fail if it cannont find libmarfs at all.

This merge will need to wait until we have merged `mc-development` branch into MarFS master.
