### PR TITLE
Build Process Refinement

### DIFF
--- a/autogen
+++ b/autogen
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ ! -d m4 ]
-then
-  mkdir m4
-fi
-
 if [ ! -d bin ]
 then
   mkdir bin

--- a/configure.ac
+++ b/configure.ac
@@ -88,15 +88,15 @@ AS_IF([test x$enable_CTM == xxattrs],
       [AC_MSG_ERROR([Usage: --enable-CTM=@<:@ {xattrs|files|no| }@:>@ ]) ])
 
 
-### AM_PROG_CC_C_O
-AC_PROG_CXX_C_O
-#works with 2.6 and above
-#AC_PROG_CC_C99
-
-m4_pattern_allow([AM_PROG_AR])
-m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AC_PROG_LIBTOOL
-AC_CONFIG_MACRO_DIR([m4])
+# ### AM_PROG_CC_C_O
+# AC_PROG_CXX_C_O
+# #works with 2.6 and above
+# #AC_PROG_CC_C99
+# 
+# m4_pattern_allow([AM_PROG_AR])
+# m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+# AC_PROG_LIBTOOL
+# AC_CONFIG_MACRO_DIR([m4])
 
 
 # checks for header files.
@@ -106,6 +106,12 @@ AS_IF([test x$enable_s3 == xyes],
 )
 AS_IF([test x$enable_marfs == xyes],
   [AC_CHECK_HEADERS([common.h marfs_ops.h aws4c.h aws4c_extra.h])]
+)
+AS_IF([test x$enable_s3 == xyes  ||  test x$enable_marfs == xyes], [
+  PKG_CHECK_MODULES(AWSXML, libxml-2.0)
+  AC_SUBST(AWSXML_CFLAGS)
+  AC_SUBST(AWSCML_LIBS)
+  ]
 )
 
 # # check for adequate mpi support

--- a/configure.ac
+++ b/configure.ac
@@ -88,17 +88,6 @@ AS_IF([test x$enable_CTM == xxattrs],
       [AC_MSG_ERROR([Usage: --enable-CTM=@<:@ {xattrs|files|no| }@:>@ ]) ])
 
 
-# ### AM_PROG_CC_C_O
-# AC_PROG_CXX_C_O
-# #works with 2.6 and above
-# #AC_PROG_CC_C99
-# 
-# m4_pattern_allow([AM_PROG_AR])
-# m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-# AC_PROG_LIBTOOL
-# AC_CONFIG_MACRO_DIR([m4])
-
-
 # checks for header files.
 AC_CHECK_HEADERS([sys/vfs.h gpfs.h gpfs_fcntl.h dmapi.h xattr.h])
 AS_IF([test x$enable_s3 == xyes],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,11 +53,11 @@ endif
 supportlib_ldflags=-lssl
 
 
-__top_builddir__bin_pftool_CFLAGS   = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(s3_cflags)
+__top_builddir__bin_pftool_CFLAGS   = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(s3_cflags) @AWSXML_CFLAGS@
 
-__top_builddir__bin_pftool_CXXFLAGS = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(s3_cflags)
+__top_builddir__bin_pftool_CXXFLAGS = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(s3_cflags) @AWSXML_CFLAGS@
 
-__top_builddir__bin_pftool_LDFLAGS  = $(generic_ldflags) $(supportlib_ldflags) $(s3_ldflags) $(marfs_ldflags) $(allstatic_ldflags)
+__top_builddir__bin_pftool_LDFLAGS  = $(generic_ldflags) $(supportlib_ldflags) $(s3_ldflags) $(marfs_ldflags) $(allstatic_ldflags) @AWSXML_LIBS@
 
 
 


### PR DESCRIPTION
These commits make a few minor changes to the pftool build process to include libxml2 headers without the need for the user to define an extra '-I' path and to correct issue #91.