### PR TITLE
fix xattr usage using new glibc sys/xattr.h

### DIFF
--- a/src/cta.c
+++ b/src/cta.c
@@ -79,7 +79,7 @@ int populateCTA(CTM *ctmptr, long numchunks, size_t chunksize) {
 	if((axist = getxattr(ctmptr->chnkfname, CTA_CHNKNUM_XATTR, (void *)&anumchunks, sizeof(long))) < 0) {
 	  int syserr = errno;						// preserve errno
 
-	  if(syserr == ENOATTR) {					// no xattr for chnknum exists for file
+	  if(syserr == ENODATA) {					// no xattr for chnknum exists for file
 	    anumchunks = numchunks;					// use the parameters passed in
 	    achunksize = chunksize;
 	  }
@@ -192,15 +192,15 @@ int foundCTA(const char *transfilename) {
 
 									// testing for number of chunks xattr (and making sure file exists)
 	if((rc=getxattr(transfilename, CTA_CHNKNUM_XATTR, nullbuf, 0)) <= 0) {
-	  if(!rc || errno == ENOENT || errno == ENOATTR || errno == ENOTSUP) return(FALSE);
+	  if(!rc || errno == ENOENT || errno == ENODATA || errno == ENOTSUP) return(FALSE);
 	}
 									// testing for chunk size xattr
 	if((rc=getxattr(transfilename, CTA_CHNKSZ_XATTR, nullbuf, 0)) <= 0) {
-	  if(!rc || errno == ENOATTR) return(FALSE);
+	  if(!rc || errno == ENODATA) return(FALSE);
 	}
 									// testing for chunk flags xattr
 	if((rc=getxattr(transfilename, CTA_CHNKFLAGS_XATTR, nullbuf, 0)) <= 0) {
-	  if(!rc || errno == ENOATTR) return(FALSE);
+	  if(!rc || errno == ENODATA) return(FALSE);
 	}
 	return(TRUE);
 }

--- a/src/ctm.h
+++ b/src/ctm.h
@@ -21,7 +21,7 @@
 
 #include "config.h"
 #include "pfutils.h"
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include <asm/bitsperlong.h>
 #ifndef BITS_PER_LONG


### PR DESCRIPTION
Hello, 

I'm trying to build pftool versus atrr-2.4.48 and had some error.
```
make[3]: Entering directory '/local/gensoft2/src/pftool/pftool-1.12-beta/src'
mpic++ -DHAVE_CONFIG_H -I. -I..   -I/local/gensoft2/lib/attr/2.4.48/include -I/local/gensoft2/exe/openmpi/4.0.2/include  -O3      -g  -MT __top_builddir__bin_pftool-cta.o -MD -MP -MF .deps/__top_builddir__bin_pftool-cta.Tpo -c -o __top_builddir__bin_pftool-cta.o `test -f 'cta.c' || echo './'`cta.c
In file included from cta.c:38:
ctm.h:24:10: fatal error: attr/xattr.h: No such file or directory
   24 | #include <attr/xattr.h>
      |          ^~~~~~~~~~~~~~
```

attr/xattr.h was removed on attr-2.4.48 because of conflicts with new glibc sys/xattr.h

side effect is that ENOATTR is no longer definder and should be replaced by ENODATA
as described on previous attr/xattr manpages 
```
ENOATTR 

    The named attribute does not exist, or the process has no access to this attribute. (ENOATTR is defined to be a synonym for ENODATA in <attr/xattr.h>.) 
```