### PR TITLE
Enable the use of O_DIRECT on aligned IO with fallback to normal IO if O_DIRECT fails.

### DIFF
--- a/etc/pftool.mpi.cfg
+++ b/etc/pftool.mpi.cfg
@@ -23,6 +23,9 @@ logging: True
 #Enables n-to-1 writing
 parallel_dest: True
 
+#Enables attempts to use O_DIRECT on read/write
+direct_io: True
+
 #Enable a darshan logging tool
 darshanlib: /usr/projects/darshan/sw/toss-x86_64/lib/libdarshan.so
 

--- a/scripts/pfcm
+++ b/scripts/pfcm
@@ -67,6 +67,8 @@ def main(parser):
 
     commands.add("-C", config.chunk_at)
     commands.add("-S", config.chunk_size)
+    if config.direct_io:
+        commands.add("-B")
     src_fixed = pfs.get_fixed_source(args.source_path,args.symlinks)
     dest_fixed = pfs.get_fixed_dest(args.dest_path,args.symlinks)
     commands.add("-c", *dest_fixed)

--- a/scripts/pfcp
+++ b/scripts/pfcp
@@ -89,6 +89,9 @@ def main(parser):
         commands.add("-e")
         commands.add(args.exclude)
 
+    if config.direct_io:
+            commands.add("-B")
+
     try:
         if config.parallel_dest:
             commands.add("-P")

--- a/scripts/pfscripts.py
+++ b/scripts/pfscripts.py
@@ -282,6 +282,7 @@ class Config:
             self.mpirun = config.get("environment", "mpirun")
             self.parallel_dest = config.getboolean(
                 "environment", "parallel_dest")
+            self.direct_io = config.getboolean("environment", "direct_io")
             self.darshan_lib = config.get("environment", "darshanlib")
             # at some point write size chunk_at and chunk_size were optional
             # that is no longer the case

--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -220,6 +220,7 @@ int main(int argc, char *argv[])
         o.dest_fstype = UNKNOWN_FS;
         strncpy(o.jid, "TestJob", 128);
         o.parallel_dest = 0;
+        o.direct = 0;
         o.blocksize = (1024 * 1024);
         o.chunk_at = (10ULL * 1024 * 1024 * 1024); // 10737418240
         o.chunksize = (10ULL * 1024 * 1024 * 1024);
@@ -241,7 +242,7 @@ int main(int argc, char *argv[])
 #endif
 
         // start MPI - if this fails we cant send the error to thtooloutput proc so we just die now
-        while ((c = getopt(argc, argv, "p:c:j:w:i:s:C:S:a:f:d:W:A:t:X:x:z:e:DorlPM:nhvg")) != -1)
+        while ((c = getopt(argc, argv, "p:c:j:w:i:s:C:S:a:f:d:W:A:t:X:x:z:e:DorlPM:nhvgB")) != -1)
         {
             switch (c)
             {
@@ -393,6 +394,10 @@ int main(int argc, char *argv[])
                 o.exclude[PATHSIZE_PLUS - 1] = '\0';
                 break;
 
+            case 'B':
+		o.direct = 1; // use direct IO / O_DIRECT
+		break;
+
             case 'h':
                 //Help -- incoming!
                 usage();
@@ -478,6 +483,7 @@ int main(int argc, char *argv[])
     MPI_Bcast(&o.dest_fstype, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
     MPI_Bcast(&o.different, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
     MPI_Bcast(&o.parallel_dest, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
+    MPI_Bcast(&o.direct, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
     MPI_Bcast(&o.work_type, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
     MPI_Bcast(&o.meta_data_only, 1, MPI_INT, MANAGER_PROC, MPI_COMM_WORLD);
     MPI_Bcast(&o.blocksize, 1, MPI_DOUBLE, MANAGER_PROC, MPI_COMM_WORLD);

--- a/src/pfutils.h
+++ b/src/pfutils.h
@@ -269,6 +269,7 @@ struct options
     FSType dest_fstype; // specifies the FS type of the destination
     int different;
     int parallel_dest;
+    int direct;
     int work_type;
     int meta_data_only;
     size_t blocksize;


### PR DESCRIPTION
Allows the option to enable O_DIRECT for reading/writing on files/chunks that align with 4K pages and on filesystems that support O_DIRECT.  If the O_DIRECT option is enabled in the config, the read/write paths will attempt to use O_DIRECT for any page-aligned IO and fall back to standard buffered IO for any other IO.  If the source or destination filesystem are incapable of O_DIRECT operation they silently fall back to buffered IO.