### PR TITLE
Minor Adjustment to Include CONDUIT 'NOMOVE' Messages

### DIFF
--- a/src/Path.h
+++ b/src/Path.h
@@ -2267,7 +2267,7 @@ public:
       {
          _errno = errno;
       }
-      unset(DID_STAT);
+      //unset(DID_STAT); #gransom edit, unsure why this is here
       return (_rc == 0);
    }
 
@@ -2278,7 +2278,7 @@ public:
       {
          _errno = errno;
       }
-      unset(DID_STAT);
+      //unset(DID_STAT); #gransom edit, unsure why this is here
       return (_rc == 0);
    }
 

--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -2126,7 +2126,11 @@ void worker_output(int rank, int sending_rank, int log, char *output_buffer, int
     }
     if (log < 2)
     {
+#ifdef CONDUIT
+        if (sending_rank == MANAGER_PROC  ||  strncmp( msg, "#CONDUIT-MSG ", 13 ) == 0)
+#else
         if (sending_rank == MANAGER_PROC)
+#endif
         {
             printf("%s", msg);
         }


### PR DESCRIPTION
Warns CONDUIT of the presence of dir perms which would prevent the running user from removing source dir contents, as in the case of a 'mv' operation.