### PR TITLE
ChunkSize Calculation Fixes for MarFS w/ CONDUIT Support

### DIFF
--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -3048,7 +3048,7 @@ void process_stat_buffer(path_item *path_buffer,
                 if (parallel_dest)
                 {
                     CTM *ctm = (CTM *)NULL; // CTM structure used with chunked files
-#ifndef CONDUIT
+
                     // --- prepare for chunking
                     //
                     // MarFS will adjust a given chunksize to match (some
@@ -3058,11 +3058,16 @@ void process_stat_buffer(path_item *path_buffer,
                     // into each object.  (i.e. chunk_size is smaller than
                     // the actual amount to be written, leaving enough room
                     // for recovery-info)
+#ifdef CONDUIT
+                    if ( !(do_unlink) ) {
+#endif
                     chunk_size = p_out->chunksize(p_work->st().st_size, o.chunksize);
 
                     // if the dest has no specific required chunk size, use the source chunk size instead
                     if ( chunk_size == o.chunksize  &&  !(p_out->supports_n_to_1()) ) {
                         chunk_size = p_work->chunksize(p_work->st().st_size, o.chunksize);
+                    }
+#ifdef CONDUIT
                     }
 #endif
                     chunk_at = p_out->chunk_at(o.chunk_at);

--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -2829,13 +2829,14 @@ void process_stat_buffer(path_item *path_buffer,
                 //   3 = CTM mis-match
                 //   4 = CTM match, but temp-file is gone (treat as mis-match)
                 //
+#ifndef CONDUIT
                 int temp_exists = check_temporary(p_work, &out_node);
                 if (temp_exists)
                 {
                     dest_exists = temp_exists; //restart with a temporary file
                 }
                 // }
-
+#endif
                 // avoid redundant 'stat's
                 dest_has_ctm = (dest_exists > 1);
 
@@ -3046,7 +3047,7 @@ void process_stat_buffer(path_item *path_buffer,
                 if (parallel_dest)
                 {
                     CTM *ctm = (CTM *)NULL; // CTM structure used with chunked files
-
+#ifndef CONDUIT
                     // --- prepare for chunking
                     //
                     // MarFS will adjust a given chunksize to match (some
@@ -3063,7 +3064,7 @@ void process_stat_buffer(path_item *path_buffer,
                     if ( chunk_size == o.chunksize  &&  !(p_out->supports_n_to_1()) ) {
                         chunk_size = p_work->chunksize(p_work->st().st_size, o.chunksize);
                     }
-
+#endif
                     int ctmExists = 0;
 
                     // handle zero-length source file - because it will not

--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -2761,6 +2761,7 @@ void process_stat_buffer(path_item *path_buffer,
     {
         process = 0;
         pre_process = 0;
+        chunk_size = 0;
 
         path_item &work_node = path_buffer[i]; // avoid a copy
 
@@ -3058,13 +3059,13 @@ void process_stat_buffer(path_item *path_buffer,
                     // the actual amount to be written, leaving enough room
                     // for recovery-info)
                     chunk_size = p_out->chunksize(p_work->st().st_size, o.chunksize);
-                    chunk_at = p_out->chunk_at(o.chunk_at);
 
                     // if the dest has no specific required chunk size, use the source chunk size instead
                     if ( chunk_size == o.chunksize  &&  !(p_out->supports_n_to_1()) ) {
                         chunk_size = p_work->chunksize(p_work->st().st_size, o.chunksize);
                     }
 #endif
+                    chunk_at = p_out->chunk_at(o.chunk_at);
                     int ctmExists = 0;
 
                     // handle zero-length source file - because it will not


### PR DESCRIPTION
Minor alterations to pftool CONDUIT-enabled chunk-size calculation, to avoid inheriting the MarFS object bounds settings from an existing chunked file target which pftool is overwriting with a fresh copy.