### PR TITLE
Feature Separation ( CONDUIT / Restart / Tmpfile ) and Chunking Fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,14 @@ AC_ARG_ENABLE(conduit,
    AS_HELP_STRING([  --enable-conduit], [Enable extra Conduit message output, disable tempfile logic, disable persistent CTM]))
 AM_CONDITIONAL([CONDUIT], [test x$enable_conduit = xyes])
 
+AC_ARG_ENABLE([tmpfile],
+              AS_HELP_STRING( [--disable-tmpfile], [Disable output to temporary file during parallel write @{:@ CONDUIT support forces this off @:}@] ) )
+AM_CONDITIONAL([TMPFILE], [test "x$enable_tmpfile" = "xyes"  &&  test "x$enable_conduit" != "xyes"])
+
+AC_ARG_ENABLE([restart],
+              AS_HELP_STRING( [--disable-restart], [Disable restartability of parallel writes and output of CTM info @{:@ CONDUIT support forces this off @:}@] ) )
+AM_CONDITIONAL([RESTART], [test "x$enable_restart" = "xyes"  &&  test "x$enable_conduit" != "xyes"])
+
 AC_CONFIG_HEADER([config.h])
 
 
@@ -210,5 +218,8 @@ LDFLAGS  : $LDFLAGS
 LIBS     : $LIBS
 CPPFLAGS : $CPPFLAGS
 CPP      : $CPP
+
+CONDUIT Support : $enable_conduit
+Tempfile Output : $enable_tmpfile
 
 EOF

--- a/configure.ac
+++ b/configure.ac
@@ -32,9 +32,10 @@ AC_ARG_ENABLE(s3,
    AS_HELP_STRING([  --enable-s3], [enable S3 support]))
 AM_CONDITIONAL([S3], [test x$enable_s3 = xyes])
 
+MARFS_ENABLED="DISABLED"
 AC_ARG_ENABLE(marfs,
    AS_HELP_STRING([  --enable-marfs], [enable marfs support]))
-AM_CONDITIONAL([MARFS], [test x$enable_marfs = xyes])
+AM_CONDITIONAL([MARFS], [test x$enable_marfs = xyes]  &&  MARFS_ENABLED="ENABLED")
 
 AC_ARG_ENABLE(old_marfs,
    AS_HELP_STRING([  --enable-old_marfs], [enable old_marfs support]))
@@ -55,17 +56,20 @@ AC_ARG_ENABLE(debug,
    AS_HELP_STRING([  --enable-debug], [build with -O0, instead of -O3]))
 AM_CONDITIONAL([DEBUG], [test "x$enable_debug" = xyes])
 
+CONDUIT_ENABLED="DISABLED"
 AC_ARG_ENABLE(conduit,
    AS_HELP_STRING([  --enable-conduit], [Enable extra Conduit message output, disable tempfile logic, disable persistent CTM]))
-AM_CONDITIONAL([CONDUIT], [test x$enable_conduit = xyes])
+AM_CONDITIONAL([CONDUIT], [test x$enable_conduit = xyes]  &&  CONDUIT_ENABLED="ENABLED")
 
+TMPFILE_ENABLED="DISABLED"
 AC_ARG_ENABLE([tmpfile],
               AS_HELP_STRING( [--disable-tmpfile], [Disable output to temporary file during parallel write @{:@ CONDUIT support forces this off @:}@] ) )
-AM_CONDITIONAL([TMPFILE], [test "x$enable_tmpfile" = "xyes"  &&  test "x$enable_conduit" != "xyes"])
+AM_CONDITIONAL([TMPFILE], [( test "x$enable_tmpfile" = "xyes"  ||  test "x$enable_tmpfile" = "x" )  &&  test "x$CONDUIT_ENABLED" = "xDISABLED"]  &&  TMPFILE_ENABLED="ENABLED")
 
+RESTART_ENABLED="DISABLED"
 AC_ARG_ENABLE([restart],
               AS_HELP_STRING( [--disable-restart], [Disable restartability of parallel writes and output of CTM info @{:@ CONDUIT support forces this off @:}@] ) )
-AM_CONDITIONAL([RESTART], [test "x$enable_restart" = "xyes"  &&  test "x$enable_conduit" != "xyes"])
+AM_CONDITIONAL([RESTART], [( test "x$enable_restart" = "xyes"  ||  test "x$enable_restart" = "x" )  &&  test "x$CONDUIT_ENABLED" = "xDISABLED"]  &&  RESTART_ENABLED="ENABLED")
 
 AC_CONFIG_HEADER([config.h])
 
@@ -219,7 +223,11 @@ LIBS     : $LIBS
 CPPFLAGS : $CPPFLAGS
 CPP      : $CPP
 
-CONDUIT Support : $enable_conduit
-Tempfile Output : $enable_tmpfile
+PREFIX   : $prefix
+
+MARFS Support   : $MARFS_ENABLED
+CONDUIT Support : $CONDUIT_ENABLED
+Tempfile Output : $TMPFILE_ENABLED
+Restartability  : $RESTART_ENABLED
 
 EOF

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,14 +38,20 @@ if S3
   s3_ldflags=$(_s3_ldflags) -laws4c -laws4c_extra -lcurl -lxml2
 endif
 
+feature_enable_cflags =
 if MARFS
-  marfs_cflags=-DMARFS
+  feature_enable_cflags += -DMARFS
 install-exec-local:
 	chmod u+s $(bindir)/pftool
 endif
-
 if CONDUIT
-  conduit_cflags=-DCONDUIT
+  feature_enable_cflags += -DCONDUIT
+endif
+if TMPFILE
+  feature_enable_cflags += -DTMPFILE
+endif
+if RESTART
+  feature_enable_cflags += -DRESTART
 endif
 
 if OLD_MARFS
@@ -63,9 +69,9 @@ endif
 supportlib_ldflags=-lssl
 
 
-__top_builddir__bin_pftool_CFLAGS   = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(conduit_cflags) $(s3_cflags) @AWSXML_CFLAGS@
+__top_builddir__bin_pftool_CFLAGS   = $(generic_cflags) $(syndata_cflags) $(feature_enable_cflags) $(s3_cflags) @AWSXML_CFLAGS@
 
-__top_builddir__bin_pftool_CXXFLAGS = $(generic_cflags) $(syndata_cflags) $(marfs_cflags) $(conduit_cflags) $(s3_cflags) @AWSXML_CFLAGS@
+__top_builddir__bin_pftool_CXXFLAGS = $(generic_cflags) $(syndata_cflags) $(feature_enable_cflags) $(s3_cflags) @AWSXML_CFLAGS@
 
 __top_builddir__bin_pftool_LDFLAGS  = $(generic_ldflags) $(supportlib_ldflags) $(s3_ldflags) $(marfs_ldflags) $(allstatic_ldflags) @AWSXML_LIBS@
 

--- a/src/ctm.c
+++ b/src/ctm.c
@@ -505,7 +505,11 @@ int check_ctm_match(const char* src_to_hash, const char* dest)
 				// Our attempt to stat such a file (below) would fail with ENOTDIR.
 				ret = 4;
 			}
+#ifdef TMPFILE
 			else if (stat(dest_temp, &st) && (errno != ENOENT)) {
+#else
+			else if (stat(dest, &st) && (errno != ENOENT)) {
+#endif
 				ret = -errno;    // stat failed for some reason other than ENOENT
 			}
 			else if (errno == ENOENT) {

--- a/src/ctm.h
+++ b/src/ctm.h
@@ -45,8 +45,8 @@ typedef int (*ctm_delete_fn_t)(const char *chnkfname);
 // different methods in the way chunk metadata is stored and accessed
 enum ctm_impltype {
 	CTM_NONE,					// no CTM routines/functions. Typically means there is no file to transfer
-#ifdef CONDUIT
-	CTM_MEM,					// just fake a CTM store so we can use the in-memory structures with CONDUIT
+#ifndef RESTART
+	CTM_MEM,					// just fake a CTM store so we can use the in-memory structures without a backing file/xattr
 #endif
 	CTM_FILE,					// use file-based routines/functions to manage chunk metadata
 	CTM_XATTR,					// user xattr routines/functions to manage chunk metadata

--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -2479,8 +2479,19 @@ int maybe_pre_process(int pre_process,
                       ssize_t* chunk_size)
 {
 
-    if (o.work_type != COPYWORK)
+    if (o.work_type != COPYWORK) {
+        // try to set chunk_size, regardless
+        if ( chunk_size  &&  *chunk_size < 1 ) {
+            ssize_t chnksztmp = p_out->chunksize(p_work->st().st_size, o.chunksize);
+            if ( chnksztmp < 1 ) {
+                errsend_fmt(NONFATAL, "failed to identify chunk size value for %s, %s: %s\n",
+                            p_out->path(), p_work->path(), strerror(errno));
+                return -1;
+            }
+            *chunk_size = chnksztmp;
+        }
         return 0;
+    }
 
     if (pre_process == 1)
     {

--- a/src/pfutils.cpp
+++ b/src/pfutils.cpp
@@ -447,7 +447,7 @@ void get_output_path(path_item *out_node, // fill in out_node.path
     }
     if (path_slice_duped)
         free((void *)path_slice);
-#ifndef CONDUIT
+#ifdef TMPFILE
     if ((rename_flag == 1) && (src_node->packable == 0) && strcmp(dest_node->path, "/dev/null"))
     {
         //need to create temporary file name
@@ -1130,7 +1130,7 @@ int update_stats(PathPtr p_src,
         errsend_fmt(NONFATAL, "update_stats -- Failed to change atime/mtime %s: %s\n",
                     p_dest->path(), p_dest->strerror());
     }
-#ifndef CONDUIT
+#ifdef TMPFILE
     if (!p_src->get_packable() && p_src->st().st_size > o.chunk_at)
     {
         const char *plus_sign = strrchr((const char *)p_dest->path(), '+');
@@ -1518,7 +1518,6 @@ void errsend(Lethality fatal, const char *error_text)
     else
         snprintf(errormsg, MESSAGESIZE, "ERROR NONFATAL: %s\n", error_text);
 
-    // errormsg[MESSAGESIZE -1] = 0; /* no need for this */
     errsend_internal(fatal, errormsg);
 }
 


### PR DESCRIPTION
 * Separated enable flags for CONDUIT / Transfer Restartability / Temporary File Output
 * Added 'configure' output to indicate enabled/disabled status for the above as well as MarFS support and prefix tgt
 * Corrected a bug associated with chunked file overwrite when outputting to a tmpfile with restart enabled