### PR TITLE
Formatting and compare changes, Lustre dir stat() bypass.

### DIFF
--- a/src/Path.h
+++ b/src/Path.h
@@ -1073,6 +1073,7 @@ public:
    }
    virtual bool opendir()
    {
+      do_stat_internal(); // this fixes a Lustre issue when server access upcall isn't set
       _dirp = ::opendir(_item->path);
       if (!bool(_dirp))
       {


### PR DESCRIPTION
Various changes to ensure read-only files are copied without issue, formatting of output messages is correct, and an annoying extra directory stat to bypass a Lustre client issue.  Updated compare logic to ensure lingering CTM doesn't cause an improper invalidation of a good comparison.  Updated chunk calculations to be optimistic about chunk size even if detection fails.  No need to make noise for something that can fail nicely later (or work without an optimal chunk detect).