### PR TITLE
Preserve Option Edits

### DIFF
--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -383,6 +383,10 @@ int main(int argc, char *argv[])
             fprintf(stderr, "'-n' can't be used with '-w 2'\n");
             return -1;
         }
+        if ( geteuid() == 0 )
+        {
+            o.preserve = 2; // default to 'preserve' + ownership checks for root, always
+        }
 
         // '-g' allows controlled debugging.
         // Wait for someone to attach gdb, before proceeding.
@@ -2110,10 +2114,10 @@ void worker_readdir(int rank,
                 }
 
                 // if running as root, always update destination dir with original ownership
-                // non-root user can also attempt this, by setting "preserve" (with -o)
+                // otherwise, allways attempt to preserve group
                 PRINT_IO_DEBUG("Creating dir (%s) for input dir (%s) with perms (%d) and gid (%d)\n",
                                p_dir->path(), p_work->path(), p_work->node().st.st_mode, p_work->node().st.st_gid);
-                if (geteuid() == 0)
+                if (o.preserve > 1)
                 {
                     if (!p_dir->lchown(p_work->node().st.st_uid, p_work->node().st.st_gid))
                     {
@@ -2121,7 +2125,7 @@ void worker_readdir(int rank,
                                     p_dir->path(), p_dir->strerror());
                     }
                 }
-                else if (o.preserve)
+                else
                 {
                     if (!p_dir->lchown(geteuid(), p_work->node().st.st_gid))
                     {

--- a/src/pfutils.cpp
+++ b/src/pfutils.cpp
@@ -982,8 +982,8 @@ int update_stats(PathPtr p_src,
     PathPtr p_dest = p_dst;
 
     // if running as root, always update <dest_file> owner  (without following links)
-    // non-root user can also attempt this, by setting "preserve" (with -o)
-    if (0 == geteuid())
+    // always attempt to chown group
+    if (o.preserve > 1)
     {
         if (!p_dest->lchown(p_src->st().st_uid, p_src->st().st_gid))
         {
@@ -991,7 +991,7 @@ int update_stats(PathPtr p_src,
                         p_dest->path(), p_dest->strerror());
         }
     }
-    else if (o.preserve)
+    else
     {
         if (!p_dest->lchown(geteuid(), p_src->st().st_gid))
         {
@@ -1890,8 +1890,8 @@ int samefile(PathPtr p_src, PathPtr p_dst, const struct options &o, int dst_has_
     // (satisfied conditions -> "same" file)
 
     if (src.st.st_size == dst.st.st_size && (src.st.st_mtime == dst.st.st_mtime || S_ISLNK(src.st.st_mode))
-        // only chown if preserve set
-        && (((src.st.st_uid == dst.st.st_uid) && (src.st.st_gid == dst.st.st_gid)) || !o.preserve)
+        // only consider gid a 'difference' if preserve set, only check uid if running as root ( o.preserve > 1 )
+        && (!o.preserve  ||  ((src.st.st_gid == dst.st.st_gid)  &&  (o.preserve <= 1  ||  src.st.st_uid == dst.st.st_uid)))
     )
     {
         // class-specific techniques (e.g. MarFS file has RESTART?)


### PR DESCRIPTION
Always set source GID on created files+dirs.  Only consider UID mismatch a 'recopy' condition if running as root.