### PR TITLE
Best Effort Only for Output GID

### DIFF
--- a/src/pftool.cpp
+++ b/src/pftool.cpp
@@ -2104,8 +2104,8 @@ void worker_readdir(int rank,
                 }
                 else
                 {
-                    if (!p_dir->lchown(geteuid(), p_work->node().st.st_gid))
-                    {
+                    if (!p_dir->lchown(geteuid(), p_work->node().st.st_gid) && o.preserve)
+                    {   // only report a failure if 'preserve' option was explicitly set
                         errsend_fmt(NONFATAL, "update_stats -- Failed to set group ownership %s: %s\n",
                                     p_dir->path(), p_dir->strerror());
                     }

--- a/src/pfutils.cpp
+++ b/src/pfutils.cpp
@@ -993,8 +993,8 @@ int update_stats(PathPtr p_src,
     }
     else
     {
-        if (!p_dest->lchown(geteuid(), p_src->st().st_gid))
-        {
+        if (!p_dest->lchown(geteuid(), p_src->st().st_gid) && o.preserve)
+        {   // only report a failure if 'preserve' option was explicitly set
             errsend_fmt(NONFATAL, "update_stats -- Failed to set group ownership %s: %s\n",
                         p_dest->path(), p_dest->strerror());
         }


### PR DESCRIPTION
Only report a failure to chown() output GID if 'o.preserve' arg was explicitly set