### PR TITLE
CONDUIT / TMPFILE / RESTART Support Independence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,12 +56,12 @@ AM_CONDITIONAL([CONDUIT], [test x$enable_conduit = xyes]  &&  CONDUIT_ENABLED="E
 TMPFILE_ENABLED="DISABLED"
 AC_ARG_ENABLE([tmpfile],
               AS_HELP_STRING( [--disable-tmpfile], [Disable output to temporary file during parallel write @{:@ CONDUIT support forces this off @:}@] ) )
-AM_CONDITIONAL([TMPFILE], [( test "x$enable_tmpfile" = "xyes"  ||  test "x$enable_tmpfile" = "x" )  &&  test "x$CONDUIT_ENABLED" = "xDISABLED"]  &&  TMPFILE_ENABLED="ENABLED")
+AM_CONDITIONAL([TMPFILE], [ test "x$enable_tmpfile" = "xyes"  ||  test "x$enable_tmpfile" = "x" ]  &&  TMPFILE_ENABLED="ENABLED")
 
 RESTART_ENABLED="DISABLED"
 AC_ARG_ENABLE([restart],
               AS_HELP_STRING( [--disable-restart], [Disable restartability of parallel writes and output of CTM info @{:@ CONDUIT support forces this off @:}@] ) )
-AM_CONDITIONAL([RESTART], [( test "x$enable_restart" = "xyes"  ||  test "x$enable_restart" = "x" )  &&  test "x$CONDUIT_ENABLED" = "xDISABLED"]  &&  RESTART_ENABLED="ENABLED")
+AM_CONDITIONAL([RESTART], [ test "x$enable_restart" = "xyes"  ||  test "x$enable_restart" = "x" ]  &&  RESTART_ENABLED="ENABLED")
 
 AC_CONFIG_HEADER([config.h])
 

--- a/src/ctf.c
+++ b/src/ctf.c
@@ -321,7 +321,7 @@ int populateCTF(CTM *ctmptr, long numchunks, size_t chunksize) {
 
 	// Manage CTF file
 	stat(ctmptr->chnkfname,&sbuf);
-#ifdef CONDUIT
+#ifndef RESTART
 	if(TRUE)	// fake a stub file so we get an allocated structure back
 #else
 	if(sbuf.st_size <= SIG_DIGEST_LENGTH * 2 + 1 + DATE_STRING_MAX)


### PR DESCRIPTION
Edits to remove './configure' disable of RESTART + TMPFILE when running with '--enable-conduit' and correction to have CTM populate() bypass properly depend on RESTART feature flag in place of CONDUIT